### PR TITLE
Added dart-define compile time server url arg

### DIFF
--- a/.github/workflows/backend-deploy-prod.yml
+++ b/.github/workflows/backend-deploy-prod.yml
@@ -26,8 +26,9 @@ jobs:
         port: 22
         envs: GITHUB_SHA,ROBOFLOW_API_KEY,GEMINI_API_KEY
         script: |
+          rm -rf prod
+          git clone https://github.com/RecycleRightCSE403/RecycleRight.git prod
           cd prod/
-          git pull
           git reset --hard $GITHUB_SHA
           cd backend/
           python3 -m venv venv

--- a/.github/workflows/backend-deploy-staging.yml
+++ b/.github/workflows/backend-deploy-staging.yml
@@ -26,8 +26,9 @@ jobs:
         port: 22
         envs: GITHUB_SHA,ROBOFLOW_API_KEY,GEMINI_API_KEY
         script: |
+          rm -rf staging
+          git clone https://github.com/RecycleRightCSE403/RecycleRight.git staging
           cd staging/
-          git pull
           git reset --hard $GITHUB_SHA
           cd backend/
           python3 -m venv venv

--- a/.github/workflows/frontend-release-prod.yml
+++ b/.github/workflows/frontend-release-prod.yml
@@ -1,9 +1,8 @@
-name: frontend-release
+name: frontend-release-prod
 
 on:
   push:
     tags: 
-      - "stage**"
       - "v**"
   workflow_dispatch:
 
@@ -25,12 +24,15 @@ jobs:
     - uses: subosito/flutter-action@v2
       with:
         flutter-version: '3.16.9'
-    - run: |
+    - name: build apk
+      env:
+        SERVER_URL: ${{ secrets.SERVER_BASE_IP }}
+      run: |
         flutter pub get
-        flutter build apk
+        flutter build apk --release --dart-define SERVER_BASE_URL="$SERVER_URL"
         mv build/app/outputs/flutter-apk/app-release.apk recycle_right.apk
     - uses: softprops/action-gh-release@v1
       with:
-        prerelease: startswith(github.ref, 'refs/tags/stage')
+        prerelease: false
         files: frontend/recycleright/recycle_right.apk
       

--- a/.github/workflows/frontend-release-staging.yml
+++ b/.github/workflows/frontend-release-staging.yml
@@ -1,0 +1,38 @@
+name: frontend-release-staging
+
+on:
+  push:
+    tags: 
+      - "stage**"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  release_frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend/recycleright
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-java@v2
+      with:
+        distribution: 'zulu'
+        java-version: '11'
+    - uses: subosito/flutter-action@v2
+      with:
+        flutter-version: '3.16.9'
+    - name: build apk
+      env:
+        SERVER_URL: ${{ secrets.SERVER_BASE_IP }}
+      run: |
+        flutter pub get
+        flutter build apk --release --dart-define SERVER_BASE_URL="$SERVER_URL"
+        mv build/app/outputs/flutter-apk/app-release.apk recycle_right.apk
+    - uses: softprops/action-gh-release@v1
+      with:
+        prerelease: true
+        files: frontend/recycleright/recycle_right.apk
+      

--- a/frontend/recycleright/lib/config.dart
+++ b/frontend/recycleright/lib/config.dart
@@ -1,5 +1,4 @@
 String getServerBaseUrl() {
-  // return "http://10.0.2.2:8000:";
-  // return "http://192.168.0.102:8000";
-  return const String.fromEnvironment("SERVER_BASE_URL");
+  return const String.fromEnvironment("SERVER_BASE_URL",
+      defaultValue: "http://10.0.2.2:8000");
 }

--- a/frontend/recycleright/lib/config.dart
+++ b/frontend/recycleright/lib/config.dart
@@ -1,0 +1,5 @@
+String getServerBaseUrl() {
+  // return "http://10.0.2.2:8000:";
+  // return "http://192.168.0.102:8000";
+  return const String.fromEnvironment("SERVER_BASE_URL");
+}

--- a/frontend/recycleright/lib/results.dart
+++ b/frontend/recycleright/lib/results.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
+import 'package:recycleright/config.dart';
 import 'classification_result_card.dart';
 import 'package:http_parser/http_parser.dart';
 
@@ -26,7 +27,7 @@ class _DisplayPictureScreenState extends State<DisplayPictureScreen> {
 
   Future<void> uploadImage(String filePath) async {
     try {
-      var uri = Uri.parse('http://10.0.2.2:8000/classify_image/');
+      var uri = Uri.parse('${getServerBaseUrl()}/classify_image/');
       var request = http.MultipartRequest('POST', uri)
         ..files.add(await http.MultipartFile.fromPath(
           'file',

--- a/frontend/recycleright/lib/text_classification_result_screen.dart
+++ b/frontend/recycleright/lib/text_classification_result_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
+import 'package:recycleright/config.dart';
 import 'dart:convert';
 import 'classification_result_card.dart';
 
@@ -26,7 +27,7 @@ class _TextClassificationResultScreenState
   }
 
   Future<void> classifyText(String text) async {
-    var uri = Uri.parse('http://10.0.2.2:8000/classify_text/');
+    var uri = Uri.parse('${getServerBaseUrl()}/classify_text/');
     var response = await http.post(uri,
         headers: {"Content-Type": "application/json"},
         body: jsonEncode({"text": text}));


### PR DESCRIPTION
Allows specifying the address of the server to use when building or running the frontend app.

To use, add `--dart-define SERVER_BASE_URL="<url>"` to any flutter run/build command. If not provided, flutter will use the android emulator host pc ip address as the url, meaning you do not need to include this arg if you are running on an emulator with a locally hosted backend.